### PR TITLE
Add reachable CVE-2022-42889 (Text4Shell) via commons-text 1.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,11 @@
       <version>2.11.0</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.9</version>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.16.0</version>

--- a/src/main/java/demo/security/servlet/TemplateServlet.java
+++ b/src/main/java/demo/security/servlet/TemplateServlet.java
@@ -1,0 +1,27 @@
+package demo.security.servlet;
+
+import org.apache.commons.text.StringSubstitutor;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@WebServlet("/template")
+public class TemplateServlet extends HttpServlet {
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        String template = request.getParameter("template");
+        // CVE-2022-42889: StringSubstitutor with user-controlled input allows
+        // arbitrary code execution via script/dns/url lookups
+        String result = StringSubstitutor.replaceSystemProperties(template);
+        response.setContentType("text/html");
+        PrintWriter out = response.getWriter();
+        out.print("<p>" + result + "</p>");
+        out.close();
+    }
+}


### PR DESCRIPTION
## Purpose

Demonstrates SCA **reachability analysis** for Java on SonarQube.

## What this PR does

- Adds `commons-text:1.9` to `pom.xml` (affected by [CVE-2022-42889](https://nvd.nist.gov/vuln/detail/CVE-2022-42889), "Text4Shell")
- Adds `TemplateServlet.java` which calls `StringSubstitutor.replaceSystemProperties(userInput)` — a **direct, single-hop call** to the vulnerable function in the dependency

## Why this triggers reachability

The call graph is clear and shallow:

```
TemplateServlet.doGet()
  → StringSubstitutor.replaceSystemProperties(template)   ← vulnerable function (CVE-2022-42889)
```

User-controlled input (`template` request parameter) flows directly into the vulnerable method, making this CVE **reachable** from first-party code.

## Expected SonarQube result

After analysis, the SCA panel should show `commons-text:1.9` with `hasReachableLocations: true` for CVE-2022-42889.