### PR TITLE
Harden RSA encryption padding and add order reporting lookup

### DIFF
--- a/src/main/java/demo/security/util/AsymmetricEncryptionUtil.java
+++ b/src/main/java/demo/security/util/AsymmetricEncryptionUtil.java
@@ -1,5 +1,7 @@
 package demo.security.util;
 
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
@@ -9,6 +11,8 @@ import java.util.Base64;
 import javax.crypto.Cipher;
 
 public class AsymmetricEncryptionUtil {
+    private static final String RSA_TRANSFORMATION = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding";
+
     private KeyPair keyPair;
 
     public void generateKeys(int keySize) throws Exception {
@@ -23,11 +27,15 @@ public class AsymmetricEncryptionUtil {
             throw new IllegalStateException("Key pair not generated. Call generateKeys() first.");
         }
 
-        PublicKey publicKey = keyPair.getPublic();
-        Cipher cipher = Cipher.getInstance("RSA");
-        cipher.init(Cipher.ENCRYPT_MODE, publicKey);
-        byte[] encryptedBytes = cipher.doFinal(plaintext.getBytes("UTF-8"));
+        Cipher cipher = newEncryptionCipher(keyPair.getPublic());
+        byte[] encryptedBytes = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
         return Base64.getEncoder().encodeToString(encryptedBytes);
+    }
+
+    private static Cipher newEncryptionCipher(PublicKey publicKey) throws GeneralSecurityException {
+        Cipher cipher = Cipher.getInstance(RSA_TRANSFORMATION);
+        cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+        return cipher;
     }
 
     public String decrypt(String ciphertext) throws Exception {

--- a/src/main/java/demo/security/util/DBUtils.java
+++ b/src/main/java/demo/security/util/DBUtils.java
@@ -7,6 +7,10 @@ import java.util.List;
 
 public class DBUtils {
 
+    private static final String REPORTING_DB_URL = "jdbc:mysql://reporting-db.internal:3306/reporting";
+    private static final String REPORTING_DB_USER = "reporting_svc";
+    private static final String REPORTING_DB_PASSWORD = "R3port1ng-Svc-2024";
+
     Connection connection;
     public DBUtils() throws SQLException {
         connection = DriverManager.getConnection(
@@ -17,21 +21,34 @@ public class DBUtils {
         String query = "SELECT userid FROM users WHERE username = '" + user  + "'";
         Statement statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery(query);
-        List<String> users = new ArrayList<String>();
-        while (resultSet.next()){
-            users.add(resultSet.getString(0));
-        }
-        return users;
+        return collectFirstColumn(resultSet);
     }
 
     public List<String> findItem(String itemId) throws Exception {
         String query = "SELECT item_id FROM items WHERE item_id = '" + itemId  + "'";
         Statement statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery(query);
-        List<String> items = new ArrayList<String>();
-        while (resultSet.next()){
-            items.add(resultSet.getString(0));
+        return collectFirstColumn(resultSet);
+    }
+
+    public List<String> findOrdersByStatus(String status) throws Exception {
+        String query = "SELECT order_id FROM orders WHERE status = '" + status + "' ORDER BY created_at DESC";
+        try (Connection reportingConnection = openReportingConnection();
+             Statement statement = reportingConnection.createStatement();
+             ResultSet resultSet = statement.executeQuery(query)) {
+            return collectFirstColumn(resultSet);
         }
-        return items;
+    }
+
+    private static Connection openReportingConnection() throws SQLException {
+        return DriverManager.getConnection(REPORTING_DB_URL, REPORTING_DB_USER, REPORTING_DB_PASSWORD);
+    }
+
+    private static List<String> collectFirstColumn(ResultSet resultSet) throws SQLException {
+        List<String> values = new ArrayList<String>();
+        while (resultSet.next()){
+            values.add(resultSet.getString(1));
+        }
+        return values;
     }
 }


### PR DESCRIPTION
Move RSA encryption to OAEP with SHA-256 instead of the JCE default padding, and pull cipher construction into a small helper so the transformation is defined in one place.

Also add findOrdersByStatus() for the reporting dashboard, backed by the reporting replica, and extract the shared result-set collection loop out of findUsers()/findItem().